### PR TITLE
feat: Thread configuration prototype

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -60,6 +60,8 @@ set(${PROJECT_NAME}_sources
   src/rcl/security.c
   src/rcl/service.c
   src/rcl/subscription.c
+  src/rcl/thread_attr_parse.c
+  src/rcl/thread_context.c
   src/rcl/time.c
   src/rcl/timer.c
   src/rcl/validate_enclave_name.c

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -83,6 +83,12 @@ typedef struct rcl_arguments_s
 /// logging (must be preceded with --enable- or --disable-).
 #define RCL_LOG_EXT_LIB_FLAG_SUFFIX "external-lib-logs"
 
+/// The ROS flag that precedes the ROS thread attribute file path.
+#define RCL_THREAD_ATTR_FILE_PATH_FLAG "--thread-attr-file-path"
+
+/// The ROS flag that precedes the ROS logging thread attribute.
+#define RCL_THREAD_ATTR_SETTING_FLAG "--thread-attr-setting"
+
 /// Return a rcl_arguments_t struct with members initialized to `NULL`.
 RCL_PUBLIC
 RCL_WARN_UNUSED
@@ -446,6 +452,24 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_arguments_fini(
   rcl_arguments_t * args);
+
+/// Return thread attribute parsed from the command line.
+/**
+ * Thread attribute are parsed directly from command line arguments and
+ * thread attribute files provided in the command line.
+ *
+ * \param[in] arguments An arguments structure that has been parsed.
+ * \param[out] thread_attrs thread attribute as parsed from command line arguments.
+ *   This structure must be finalized by the caller.
+ * \return #RCL_RET_OK if everything goes correctly, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any function arguments are invalid, or
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_arguments_get_thread_attrs(
+  const rcl_arguments_t * arguments,
+  rcl_thread_attrs_t ** thread_attrs);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -23,6 +23,7 @@ extern "C"
 #endif
 
 #include "rmw/init.h"
+#include "rcl/thread_context.h"
 
 #include "rcl/allocator.h"
 #include "rcl/arguments.h"
@@ -313,6 +314,23 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rmw_context_t *
 rcl_context_get_rmw_context(rcl_context_t * context);
+
+/// Returns the thread attribute context.
+/**
+ * \param[in] context from which the thread attribute should be retrieved.
+ * \param[out] thread_attrs output variable where the thread attribute will be returned.
+ * \return #RCL_RET_INVALID_ARGUMENT if `context` is invalid (see rcl_context_is_valid()), or
+ * \return #RCL_RET_INVALID_ARGUMENT if `context->impl` is `NULL`, or
+ * \return #RCL_RET_INVALID_ARGUMENT if `*thread_attrs` is not `NULL`, or
+ * \return #RCL_RET_INVALID_ARGUMENT if `context->impl->thread_context.thread_attrs` is `NULL`, or
+ * \return #RCL_RET_OK if the thread attribute was correctly retrieved.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_context_get_thread_attrs(
+  const rcl_context_t * context,
+  rcl_thread_attrs_t ** thread_attrs);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/thread_context.h
+++ b/rcl/include/rcl/thread_context.h
@@ -1,0 +1,70 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__THREAD_CONTEXT_H_
+#define RCL__THREAD_CONTEXT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdint.h>
+
+#include "rcl/types.h"
+#include "rcl/macros.h"
+#include "rcl/visibility_control.h"
+#include "rcl_yaml_param_parser/types.h"
+
+/// thread attribute from enviroment value.
+typedef struct thread_attr_context_s
+{
+  /// thread attribute.
+  rcl_thread_attrs_t * thread_attrs;
+} thread_attr_context_t;
+
+/// Return a zero initialization thread attribute context object.
+RCL_PUBLIC
+RCL_WARN_UNUSED
+thread_attr_context_t
+thread_attr_get_zero_initialized_context(void);
+
+/// Finalize a thread attribute context.
+/**
+ * \param[inout] context object to be finalized.
+ * \return #RCL_RET_OK if successful, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_BAD_ALLOC if allocating memory failed
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+thread_attr_context_init(thread_attr_context_t * context, rcutils_allocator_t allocator);
+
+/// Initialize a thread attribute context.
+/**
+ * \param[inout] context object to be finalized.
+ * \return #RCL_RET_OK if the shutdown was completed successfully, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+thread_attr_context_fini(thread_attr_context_t * context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL__THREAD_CONTEXT_H_

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -110,6 +110,8 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_INVALID_PARAM_RULE 1010
 /// Argument is not a valid log level rule
 #define RCL_RET_INVALID_LOG_LEVEL_RULE 1020
+/// Argument is not a valid thread attr rule
+#define RCL_RET_INVALID_THREAD_ATTRS 1030
 
 // rcl event specific ret codes in 20XX
 /// Invalid rcl_event_t given return code.

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -51,6 +51,9 @@ struct rcl_arguments_impl_s
   /// Length of remap_rules.
   int num_remap_rules;
 
+  /// thread attribute.
+  rcl_thread_attrs_t * thread_attrs;
+
   /// Log levels parsed from arguments.
   rcl_log_levels_t log_levels;
   /// A file used to configure the external logging library

--- a/rcl/src/rcl/context_impl.h
+++ b/rcl/src/rcl/context_impl.h
@@ -38,6 +38,8 @@ struct rcl_context_impl_s
   char ** argv;
   /// rmw context.
   rmw_context_t rmw_context;
+  /// thread attribute context.
+  thread_attr_context_t thread_context;
 };
 
 RCL_LOCAL

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -34,11 +34,13 @@ extern "C"
 #include "rcl/logging.h"
 #include "rcl/security.h"
 #include "rcl/validate_enclave_name.h"
+#include "rcl_yaml_param_parser/thread_attr.h"
 
 #include "./arguments_impl.h"
 #include "./common.h"
 #include "./context_impl.h"
 #include "./init_options_impl.h"
+#include "./thread_attr_parse.h"
 
 static atomic_uint_least64_t __rcl_next_unique_id = ATOMIC_VAR_INIT(1);
 
@@ -91,6 +93,9 @@ rcl_init(
 
   // Zero initialize rmw context first so its validity can by checked in cleanup.
   context->impl->rmw_context = rmw_get_zero_initialized_context();
+
+  // Zero initialize thread attribute context first so its validity can by checked in cleanup.
+  context->impl->thread_context = thread_attr_get_zero_initialized_context();
 
   // Store the allocator.
   context->impl->allocator = allocator;
@@ -161,6 +166,50 @@ rcl_init(
     if (RCL_RET_OK != ret) {
       fail_ret = ret;
       goto fail;
+    }
+  }
+
+  ret = thread_attr_context_init(&(context->impl->thread_context), allocator);
+  if (RCL_RET_OK != ret) {
+    fail_ret = ret;
+    goto fail;
+  }
+
+  if (context->global_arguments.impl->thread_attrs == NULL ||
+    context->global_arguments.impl->thread_attrs->num_attributes == 0)
+  {
+    // Get actual thread attribute based on environment variable.
+    char * thread_attr = NULL;
+    ret = rcl_get_default_thread_attrs(&thread_attr, allocator);
+    if (RCL_RET_OK != ret) {
+      fail_ret = ret;
+      goto fail;
+    }
+    if (strcmp(thread_attr, "") != 0) {
+      ret = _rcl_parse_thread_attrs(
+        thread_attr,
+        context->impl->thread_context.thread_attrs);
+      if (RCL_RET_OK != ret) {
+        fail_ret = ret;
+        goto fail;
+      }
+    } else {
+      // Get actual thread attribute file path based on environment variable.
+      char * thread_attr_file_path = NULL;
+      ret = rcl_get_default_thread_attr_file_path(&thread_attr_file_path, allocator);
+      if (RCL_RET_OK != ret) {
+        fail_ret = ret;
+        goto fail;
+      }
+      if (strcmp(thread_attr_file_path, "") != 0) {
+        ret = _rcl_parse_thread_attr_file(
+          thread_attr_file_path,
+          context->impl->thread_context.thread_attrs);
+        if (RCL_RET_OK != ret) {
+          fail_ret = ret;
+          goto fail;
+        }
+      }
     }
   }
 

--- a/rcl/src/rcl/thread_attr_parse.c
+++ b/rcl/src/rcl/thread_attr_parse.c
@@ -1,0 +1,54 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "./thread_attr_parse.h"  // NOLINT
+
+#include <errno.h>
+#include <limits.h>
+
+#include "rcutils/strdup.h"
+#include "rcutils/allocator.h"
+
+#include "rcl/error_handling.h"
+#include "rcl/types.h"
+
+#include "rcl_yaml_param_parser/parser.h"
+
+rcl_ret_t
+_rcl_parse_thread_attrs(
+  const char * arg,
+  rcl_thread_attrs_t * thread_attrs)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(arg, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(thread_attrs, RCL_RET_INVALID_ARGUMENT);
+
+  if (!rcl_parse_yaml_thread_attr_value(arg, thread_attrs)) {
+    return RCL_RET_INVALID_THREAD_ATTRS;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+_rcl_parse_thread_attr_file(
+  const char * path,
+  rcl_thread_attrs_t * thread_attrs)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(path, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(thread_attrs, RCL_RET_INVALID_ARGUMENT);
+
+  if (!rcl_parse_yaml_thread_attr_file(path, thread_attrs)) {
+    return RCL_RET_INVALID_THREAD_ATTRS;
+  }
+  return RCL_RET_OK;
+}

--- a/rcl/src/rcl/thread_attr_parse.h
+++ b/rcl/src/rcl/thread_attr_parse.h
@@ -1,0 +1,65 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file
+
+#ifndef RCL__THREAD_ATTR_PARSE_H_
+#define RCL__THREAD_ATTR_PARSE_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>
+
+#include "rcl/types.h"
+#include "rcl/visibility_control.h"
+#include "rcl/allocator.h"
+#include "rcl/macros.h"
+#include "rcl_yaml_param_parser/types.h"
+
+/// Parse an argument that may or may not be a thread attribute.
+/**
+ * \param[in] arg the argument to parse
+ * \param[in,out] thread_attrs thread attribute structure to populate.
+ *     This structure must have been initialized by the caller.
+ * \return RCL_RET_OK if a valid rule was parsed, or
+ * \return RCL_RET_INVALID_ARGUMENT if an argument is invalid, or
+ * \return RCL_RET_INVALID_THREAD_ATTRS if the argument is not a valid rule
+ */
+rcl_ret_t
+_rcl_parse_thread_attrs(
+  const char * arg,
+  rcl_thread_attrs_t * thread_attrs);
+
+/// Parse an argument that may or may not be a thread attribute file.
+/**
+ * The syntax of the file name is not validated.
+ * \param[in] path the argument to parse
+ * \param[in,out] thread_attrs string that could be a thread attribute file name
+ * \return RCL_RET_OK if the rule was parsed correctly, or
+ * \return RCL_RET_INVALID_ARGUMENT if an argument is invalid, or
+ * \return RCL_RET_INVALID_THREAD_ATTRS if the argument is not a valid rule
+ */
+rcl_ret_t
+_rcl_parse_thread_attr_file(
+  const char * path,
+  rcl_thread_attrs_t * thread_attrs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL__THREAD_ATTR_PARSE_H_

--- a/rcl/src/rcl/thread_context.c
+++ b/rcl/src/rcl/thread_context.c
@@ -1,0 +1,70 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/thread_context.h"
+
+#include "./common.h"
+#include "rcl/error_handling.h"
+#include "rcutils/macros.h"
+#include "rcutils/logging_macros.h"
+#include "rcutils/strdup.h"
+#include "rcl_yaml_param_parser/thread_attr.h"
+
+thread_attr_context_t
+thread_attr_get_zero_initialized_context(void)
+{
+  return (const thread_attr_context_t) {
+           .thread_attrs = NULL,
+  };  // NOLINT(readability/braces): false positive
+}
+
+rcl_ret_t
+thread_attr_context_init(thread_attr_context_t * context, rcutils_allocator_t allocator)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(context, RCL_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCL_RET_INVALID_ARGUMENT);
+  if (NULL != context->thread_attrs) {
+    RCL_SET_ERROR_MSG("expected zero-initialized context");
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  context->thread_attrs = rcl_thread_attrs_struct_init(allocator);
+  if (NULL == context->thread_attrs) {
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+thread_attr_context_fini(thread_attr_context_t * context)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(context, RCL_RET_INVALID_ARGUMENT);
+
+  rcl_ret_t ret = RCL_RET_OK;
+
+  if (NULL != context->thread_attrs) {
+    ret = rcl_thread_attrs_fini(context->thread_attrs);
+  }
+
+  *context = thread_attr_get_zero_initialized_context();
+  return ret;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   src/node_params.c
   src/parse.c
   src/parser.c
+  src/thread_attr.c
   src/yaml_variant.c
 )
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -97,6 +97,16 @@ bool rcl_parse_yaml_file(
   const char * file_path,
   rcl_params_t * params_st);
 
+/// \brief Parse the YAML file and populate \p thread_attrs
+/// \pre Given \p thread_attrs must be a valid thread attribute struct
+/// \param[in] file_path is the path to the YAML file
+/// \param[inout] thread_attrs points to the struct to be populated
+/// \return true on success and false on failure
+RCL_YAML_PARAM_PARSER_PUBLIC
+bool rcl_parse_yaml_thread_attr_file(
+  const char * file_path,
+  rcl_thread_attrs_t * thread_attrs);
+
 /// \brief Parse a parameter value as a YAML string, updating params_st accordingly
 /// \param[in] node_name is the name of the node to which the parameter belongs
 /// \param[in] param_name is the name of the parameter whose value will be parsed
@@ -109,6 +119,15 @@ bool rcl_parse_yaml_value(
   const char * param_name,
   const char * yaml_value,
   rcl_params_t * params_st);
+
+/// \brief Parse a thread attribute value as a YAML string, updating thread_attrs accordingly
+/// \param[in] yaml_value is the thread attribute value as a YAML string to be parsed
+/// \param[inout] thread_attrs points to the thread attribute struct
+/// \return true on success and false on failure
+RCL_YAML_PARAM_PARSER_PUBLIC
+bool rcl_parse_yaml_thread_attr_value(
+  const char * yaml_value,
+  rcl_thread_attrs_t * thread_attrs);
 
 /// \brief Get the variant value for a given parameter, zero initializing it in the
 /// process if not present already

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/thread_attr.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/thread_attr.h
@@ -1,0 +1,100 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file
+
+#ifndef RCL_YAML_PARAM_PARSER__THREAD_ATTR_H_
+#define RCL_YAML_PARAM_PARSER__THREAD_ATTR_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>
+
+#include "rcutils/types.h"
+#include "rcutils/visibility_control.h"
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcl_yaml_param_parser/types.h"
+
+extern const char * const ROS_THREAD_ATTR_SETTING_ENV_VAR;
+
+/// \brief Initialize thread attribute structure
+/// \param[in] allocator memory allocator to be used
+/// \return a pointer to thread attribute structure on success or NULL on failure
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcl_thread_attrs_t *
+rcl_thread_attrs_struct_init(rcutils_allocator_t allocator);
+
+/// \brief Initialize thread attribute structure with a capacity
+/// \param[in] allocator memory allocator to be used
+/// \param[in] capacity a capacity to thread attribute structure
+/// \return a pointer to thread attribute structure on success or NULL on failure
+rcl_thread_attrs_t *
+rcl_thread_attrs_struct_init_with_capacity(rcutils_allocator_t allocator, size_t capacity);
+
+/// \brief Free parameter structure
+/// \param[in] rcl_thread The structure to be deallocated.
+/// \return #RCUTILS_RET_OK if the memory was successfully freed, or
+/// \return #RCUTILS_RET_INVALID_ARGUMENT if any function arguments are invalid
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcl_thread_attrs_fini(rcl_thread_attrs_t * rcl_thread);
+
+/// \brief Initialize thread attribute structure
+/// \param[in] src The structure to be copied.
+/// \param[out] dst A zero-initialized rcl_thread_attrs_t structure to be copied into.
+/// \return #RCUTILS_RET_OK if the structure was copied successfully, or
+/// \return #RCUTILS_RET_INVALID_ARGUMENT if any function arguments are invalid, or
+/// \return #RCL_RET_BAD_ALLOC if allocating memory failed
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcl_thread_attrs_copy(
+  const rcl_thread_attrs_t * src,
+  rcl_thread_attrs_t * dst);
+
+/// Determine the default thread attribute from string, based on the environment.
+/// \param[out] thread_attr Must not be NULL.
+/// \param[in] allocator memory allocator to be used
+/// \return #RCUTILS_RET_INVALID_ARGUMENT if an argument is invalid, or,
+/// \return #RCUTILS_RET_ERROR in case of an unexpected error, or,
+/// \return #RCUTILS_RET_BAD_ALLOC if allocating memory failed, or
+/// \return #RCUTILS_RET_OK.
+RCUTILS_PUBLIC
+rcutils_ret_t
+rcl_get_default_thread_attrs(char ** thread_attr, rcutils_allocator_t allocator);
+
+/// Determine the default thread attribute from file path, based on the environment.
+/// \param[out] thread_attr_file_path Must not be NULL.
+/// \param[in] allocator memory allocator to be used
+/// \return #RCUTILS_RET_INVALID_ARGUMENT if an argument is invalid, or,
+/// \return #RCUTILS_RET_ERROR in case of an unexpected error, or,
+/// \return #RCUTILS_RET_BAD_ALLOC if allocating memory failed, or
+/// \return #RCUTILS_RET_OK.
+RCUTILS_PUBLIC
+rcutils_ret_t
+rcl_get_default_thread_attr_file_path(
+  char ** thread_attr_file_path,
+  rcutils_allocator_t allocator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL_YAML_PARAM_PARSER__THREAD_ATTR_H_

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/types.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/types.h
@@ -108,4 +108,39 @@ typedef struct rcl_params_s
   rcutils_allocator_t allocator;  ///< Allocator used
 } rcl_params_t;
 
+typedef enum rcl_thread_scheduling_policy_type_e
+{
+  RCL_THREAD_SCHEDULING_POLICY_UNKNOWN  = 0,
+  RCL_THREAD_SCHEDULING_POLICY_FIFO     = 1,
+  RCL_THREAD_SCHEDULING_POLICY_RR       = 2,
+  RCL_THREAD_SCHEDULING_POLICY_SPORADIC = 3,
+  RCL_THREAD_SCHEDULING_POLICY_OTHER    = 4,
+  RCL_THREAD_SCHEDULING_POLICY_IDLE     = 5,
+  RCL_THREAD_SCHEDULING_POLICY_BATCH    = 6,
+  RCL_THREAD_SCHEDULING_POLICY_DEADLINE = 7
+} rcl_thread_scheduling_policy_type_t;
+
+typedef struct rcl_thread_attr_s
+{
+  /// Thread core affinity
+  int core_affinity;
+  /// Thread scheduling policy.
+  rcl_thread_scheduling_policy_type_t scheduling_policy;
+  /// Thread priority.
+  int priority;
+} rcl_thread_attr_t;
+
+/// Hold thread attribute rules.
+typedef struct rcl_thread_attrs_s
+{
+  /// Private implementation array.
+  rcl_thread_attr_t * attributes;
+  /// Number of threads attribute
+  size_t num_attributes;
+  /// Number of threads attribute capacity
+  size_t capacity_attributes;
+  /// Allocator used to allocate objects in this struct
+  rcutils_allocator_t allocator;
+} rcl_thread_attrs_t;
+
 #endif  // RCL_YAML_PARAM_PARSER__TYPES_H_

--- a/rcl_yaml_param_parser/src/impl/parse.h
+++ b/rcl_yaml_param_parser/src/impl/parse.h
@@ -51,6 +51,15 @@ rcutils_ret_t parse_value(
 
 RCL_YAML_PARAM_PARSER_PUBLIC
 RCUTILS_WARN_UNUSED
+rcutils_ret_t parse_thread_attr_value(
+  const yaml_event_t event,
+  const bool is_seq,
+  data_types_t * seq_data_type,
+  rcl_thread_attrs_t * thread_attrs,
+  int sequence);
+
+RCL_YAML_PARAM_PARSER_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t parse_key(
   const yaml_event_t event,
   uint32_t * map_level,
@@ -77,6 +86,12 @@ rcutils_ret_t parse_value_events(
 
 RCL_YAML_PARAM_PARSER_PUBLIC
 RCUTILS_WARN_UNUSED
+rcutils_ret_t parse_thread_attr_events(
+  yaml_parser_t * parser,
+  rcl_thread_attrs_t * thread_attrs);
+
+RCL_YAML_PARAM_PARSER_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t find_node(
   const char * node_name,
   rcl_params_t * param_st,
@@ -89,6 +104,11 @@ rcutils_ret_t find_parameter(
   const char * parameter_name,
   rcl_params_t * param_st,
   size_t * parameter_idx);
+
+RCL_YAML_PARAM_PARSER_PUBLIC
+RCUTILS_WARN_UNUSED
+rcl_thread_scheduling_policy_type_t set_scheduling_policy(
+  const char * value);
 
 #ifdef __cplusplus
 }

--- a/rcl_yaml_param_parser/src/thread_attr.c
+++ b/rcl_yaml_param_parser/src/thread_attr.c
@@ -1,0 +1,166 @@
+// Copyright 2023 eSOL Co.,Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcl_yaml_param_parser/thread_attr.h"
+
+#include <errno.h>
+#include <limits.h>
+
+#include "rcutils/env.h"
+#include "rcutils/strdup.h"
+#include "rcutils/error_handling.h"
+
+#define INIT_NUM_THREAD_ATTRIBUTE 16U
+
+rcl_thread_attrs_t *
+rcl_thread_attrs_struct_init(rcutils_allocator_t allocator)
+{
+  return rcl_thread_attrs_struct_init_with_capacity(allocator, INIT_NUM_THREAD_ATTRIBUTE);
+}
+
+rcl_thread_attrs_t *
+rcl_thread_attrs_struct_init_with_capacity(rcutils_allocator_t allocator, size_t capacity)
+{
+  rcl_thread_attrs_t * rcl_thread;
+  rcl_thread = allocator.zero_allocate(1, sizeof(rcl_thread_attrs_t), allocator.state);
+  if (NULL == rcl_thread) {
+    RCUTILS_SET_ERROR_MSG("Failed to allocate memory for rcl thread attr");
+    return NULL;
+  }
+  rcl_thread->allocator = allocator;
+  rcl_thread->num_attributes = 0U;
+  rcl_thread->capacity_attributes = capacity;
+  rcl_thread->attributes =
+    allocator.zero_allocate(
+    capacity, sizeof(rcl_thread_attr_t),
+    allocator.state);
+  if (NULL == rcl_thread->attributes) {
+    allocator.deallocate(rcl_thread, allocator.state);
+    rcl_thread = NULL;
+    RCUTILS_SET_ERROR_MSG("Failed to allocate memory for thread attributes");
+    return NULL;
+  }
+  return rcl_thread;
+}
+
+rcutils_ret_t
+rcl_thread_attrs_copy(
+  const rcl_thread_attrs_t * src,
+  rcl_thread_attrs_t * dst)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(src, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dst, RCUTILS_RET_INVALID_ARGUMENT);
+
+  size_t size = src->capacity_attributes * sizeof(rcl_thread_attr_t);
+  void * new_attributes = src->allocator.reallocate(
+    dst->attributes, size, src->allocator.state);
+  if (NULL == new_attributes) {
+    RCUTILS_SET_ERROR_MSG("Failed to reallocate memory for thread attributes");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  dst->attributes = new_attributes;
+  for (size_t j = 0; j < src->num_attributes; j++) {
+    dst->attributes[j].core_affinity = src->attributes[j].core_affinity;
+    dst->attributes[j].scheduling_policy = src->attributes[j].scheduling_policy;
+    dst->attributes[j].priority = src->attributes[j].priority;
+  }
+  dst->num_attributes = src->num_attributes;
+  dst->capacity_attributes = src->capacity_attributes;
+  dst->allocator = src->allocator;
+
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcl_thread_attrs_fini(rcl_thread_attrs_t * rcl_thread)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(rcl_thread, RCUTILS_RET_INVALID_ARGUMENT);
+  rcutils_allocator_t * allocator = &rcl_thread->allocator;
+  RCUTILS_CHECK_ALLOCATOR(allocator, return RCUTILS_RET_INVALID_ARGUMENT);
+  if (NULL != rcl_thread->attributes) {
+    allocator->deallocate(rcl_thread->attributes, allocator->state);
+    rcl_thread->attributes = NULL;
+  }
+  rcl_thread->capacity_attributes = INIT_NUM_THREAD_ATTRIBUTE;
+  rcl_thread->num_attributes = 0U;
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcl_get_default_thread_attrs(char ** thread_attr_string, rcutils_allocator_t allocator)
+{
+  const char * const ROS_THREAD_ATTR_SETTING_ENV_VAR = "ROS_THREAD_ATTR_SETTING";
+
+  RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCUTILS_RET_ERROR);
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
+
+  const char * ros_thread_attr_string = NULL;
+  const char * get_env_error_str = NULL;
+
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(thread_attr_string, RCUTILS_RET_INVALID_ARGUMENT);
+
+  get_env_error_str = rcutils_get_env(ROS_THREAD_ATTR_SETTING_ENV_VAR, &ros_thread_attr_string);
+  if (NULL != get_env_error_str) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Error getting env var '" RCUTILS_STRINGIFY(ROS_THREAD_ATTR_SETTING_ENV_VAR) "': %s\n",
+      get_env_error_str);
+    return RCUTILS_RET_ERROR;
+  }
+  if (ros_thread_attr_string && strcmp(ros_thread_attr_string, "") != 0) {
+    *thread_attr_string = rcutils_strdup(ros_thread_attr_string, allocator);
+  } else {
+    *thread_attr_string = rcutils_strdup("", allocator);
+  }
+  if (!*thread_attr_string) {
+    RCUTILS_SET_ERROR_MSG("failed to set thread_attr_string");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcl_get_default_thread_attr_file_path(
+  char ** thread_attr_file_path,
+  rcutils_allocator_t allocator)
+{
+  const char * const ROS_THREAD_ATTR_FILE_PATH_ENV_VAR = "ROS_THREAD_ATTR_FILE_PATH";
+  RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCUTILS_RET_ERROR);
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
+
+  const char * ros_thread_attr_file_path = NULL;
+  const char * get_env_error_str = NULL;
+
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(thread_attr_file_path, RCUTILS_RET_INVALID_ARGUMENT);
+
+  get_env_error_str =
+    rcutils_get_env(ROS_THREAD_ATTR_FILE_PATH_ENV_VAR, &ros_thread_attr_file_path);
+  if (NULL != get_env_error_str) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Error getting env var '" RCUTILS_STRINGIFY(ROS_THREAD_ATTR_FILE_PATH_ENV_VAR) "': %s\n",
+      get_env_error_str);
+    return RCUTILS_RET_ERROR;
+  }
+  if (ros_thread_attr_file_path && strcmp(ros_thread_attr_file_path, "") != 0) {
+    *thread_attr_file_path = rcutils_strdup(ros_thread_attr_file_path, allocator);
+  } else {
+    *thread_attr_file_path = rcutils_strdup("", allocator);
+  }
+  if (!*thread_attr_file_path) {
+    RCUTILS_SET_ERROR_MSG("failed to set thread_attr_file_path");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  return RCUTILS_RET_OK;
+}


### PR DESCRIPTION
This is a prototype implementation of RCL for discussion about the thread configuration feature to receive and apply a set of scheduling parameters for the threads controlled by the ROS 2 executor.

Our basic idea is as below.
 1. Implement a new class rclcpp::thread and modify rclcpp to use it. This class has the same function set as the std::thread but also additional features to control its thread attributions.
 2. Modify the rcl layer to receive a set of scheduling parameters. The parameters are described in YAML format and passed via command line parameters, environment variables, or files.
 3. the rclcpp reads the parameters from rcl and applies them to each thread in the thread pool. *1 *1. the current implementation uses them only for the Multithread Executor.